### PR TITLE
Increase data retention to 3 days for larger exports

### DIFF
--- a/tap_eloqua/sync.py
+++ b/tap_eloqua/sync.py
@@ -191,7 +191,8 @@ def sync_bulk_obj(client, catalog, state, start_date, stream_name, bulk_page_siz
         'name': 'Singer Sync - ' + datetime.utcnow().isoformat(),
         'fields': fields,
         'filter': _filter,
-        'areSystemTimestampsInUTC': True
+        'areSystemTimestampsInUTC': True,
+        'dataRetentionDuration': 'P3D' # 3 days in ISO-8601 duration notation this can be increased up to 14 days
     }
 
     if activity_type:


### PR DESCRIPTION
`contacts` has been observed to sync through the bulk API at ~8million rows per 12 hours. The default data retention time is 12 hours, so this sets an upper limit on large data sets.

The maximum time possible for data retention is 2 weeks. The way to increase this further would be to manually delete the export from Eloqua after a successful sync, but in order to limit the scope of this change, I opted to only increase the retention to 3 days to strike a balance between resource usage and implementation complexity.