### PR TITLE
Revert "Merge pull request #11 from datamill-co/revert-10-bulk-csv"

### DIFF
--- a/tap_eloqua/__init__.py
+++ b/tap_eloqua/__init__.py
@@ -121,4 +121,4 @@ def main():
                  parsed_args.catalog,
                  parsed_args.state,
                  parsed_args.config['start_date'],
-                 int(parsed_args.config.get('bulk_page_size', 5000)))
+                 int(parsed_args.config.get('bulk_page_size', 50000)))

--- a/tap_eloqua/client.py
+++ b/tap_eloqua/client.py
@@ -89,7 +89,7 @@ class EloquaClient(object):
                           (Server5xxError, ConnectionError),
                           max_tries=5,
                           factor=2)
-    def request(self, method, path=None, url=None, **kwargs):
+    def request(self, method, path=None, url=None, stream_csv=False, **kwargs):
         self.get_access_token()
 
         if not url and self.__base_url is None:
@@ -111,6 +111,10 @@ class EloquaClient(object):
         if self.__user_agent:
             kwargs['headers']['User-Agent'] = self.__user_agent
 
+        if stream_csv:
+            kwargs['stream'] = True
+            kwargs['headers']['Accept'] = 'text/csv'
+
         with metrics.http_request_timer(endpoint) as timer:
             response = self.__session.request(method, url, **kwargs)
             timer.tags[metrics.Tag.http_status_code] = response.status_code
@@ -120,6 +124,8 @@ class EloquaClient(object):
 
         response.raise_for_status()
 
+        if stream_csv:
+            return response
         return response.json()
 
     def get(self, path, **kwargs):

--- a/tap_eloqua/sync.py
+++ b/tap_eloqua/sync.py
@@ -1,4 +1,5 @@
 import re
+import csv
 import time
 import random
 from datetime import datetime, timedelta
@@ -62,19 +63,28 @@ def write_schema(catalog, stream_id):
     schema = stream.schema.to_dict()
     singer.write_schema(stream_id, schema, stream.key_properties)
 
-def persist_records(catalog, stream_id, records):
+def persist_records(catalog, stream_id, records, updated_at_field=None):
     stream = catalog.get_stream(stream_id)
     schema = stream.schema.to_dict()
     stream_metadata = metadata.to_map(stream.metadata)
+    max_updated_at = None
     with metrics.record_counter(stream_id) as counter:
+        total_count = 0
         for record in records:
             with Transformer(
                 integer_datetime_fmt=UNIX_SECONDS_INTEGER_DATETIME_PARSING) as transformer:
                 record = transformer.transform(record,
                                                schema,
                                                stream_metadata)
+                if updated_at_field:
+                    updated_at_value = record[updated_at_field]
+                    if max_updated_at is None or updated_at_value > max_updated_at:
+                        max_updated_at = updated_at_value
+
             singer.write_record(stream_id, record)
             counter.increment()
+            total_count += 1
+        return total_count, max_updated_at
 
 def transform_export_row(row):
     out = {}
@@ -104,31 +114,35 @@ def stream_export(client,
             stream_name,
             offset,
             bulk_page_size))
+        with metrics.job_timer('export_page'):
+            stream = client.get(
+                '/api/bulk/2.0/syncs/{}/data'.format(sync_id),
+                params={
+                    'limit': bulk_page_size,
+                    'offset': offset
+                },
+                stream_csv=True,
+                endpoint='export_data')
+            offset += bulk_page_size
 
-        write_bulk_bookmark(state, stream_name, sync_id, offset, bookmark_datetime)
+            records_stream = (line.decode('utf-8') for line in stream.iter_lines())
+            records = csv.DictReader(records_stream)
+            records_transformed = map(transform_export_row, records)
 
-        data = client.get(
-            '/api/bulk/2.0/syncs/{}/data'.format(sync_id),
-            params={
-                'limit': bulk_page_size,
-                'offset': offset
-            },
-            endpoint='export_data')
-        has_more = data['hasMore']
-        offset += bulk_page_size
+            count, max_page_updated_at = persist_records(
+                catalog,
+                stream_name,
+                records_transformed,
+                updated_at_field=updated_at_field)
 
-        if 'items' in data and data['items']:
-            records = map(transform_export_row, data['items'])
-            persist_records(catalog, stream_name, records)
-
-            max_page_updated_at = max(map(lambda x: x[updated_at_field], data['items']))
             if max_updated_at is None or max_page_updated_at > max_updated_at:
                 max_updated_at = max_page_updated_at
 
-    final_datetime = max_updated_at or bookmark_datetime
-    write_bulk_bookmark(state, stream_name, None, None, final_datetime)
+            if count < bulk_page_size:
+                has_more = False
 
-    return final_datetime
+    if max_updated_at:
+        write_bookmark(state, stream_name, max_updated_at)
 
 def sync_bulk_obj(client, catalog, state, start_date, stream_name, bulk_page_size, activity_type=None):
     LOGGER.info('{} - Starting export'.format(stream_name))


### PR DESCRIPTION
In further testing, we discovered that about 2 in every 10 activity exports using the JSON format had corrupted data (values were mapped to the wrong keys). Upon testing a small export of `activity_web_visit` over ~15 runs, no failures were seen. In contrast, 2 failures were seen in 10 runs of the JSON method.

Because of this, this PR reverts the revert of the CSV method, so that we can move onto validating the overall data quality in testing.

This reverts commit 57263c6b064c66ea157afb574c6190b4a89faed2, reversing
changes made to df9ffd85a119d27a1ccb72b9d5ecf05f892ea399.