### PR TITLE
Fix/activity stream inconsistency

### DIFF
--- a/tap_eloqua/__init__.py
+++ b/tap_eloqua/__init__.py
@@ -121,4 +121,4 @@ def main():
                  parsed_args.catalog,
                  parsed_args.state,
                  parsed_args.config['start_date'],
-                 int(parsed_args.config.get('bulk_page_size', 50000)))
+                 int(parsed_args.config.get('bulk_page_size', 5000)))

--- a/tap_eloqua/client.py
+++ b/tap_eloqua/client.py
@@ -89,7 +89,7 @@ class EloquaClient(object):
                           (Server5xxError, ConnectionError),
                           max_tries=5,
                           factor=2)
-    def request(self, method, path=None, url=None, stream_csv=False, **kwargs):
+    def request(self, method, path=None, url=None, **kwargs):
         self.get_access_token()
 
         if not url and self.__base_url is None:
@@ -111,10 +111,6 @@ class EloquaClient(object):
         if self.__user_agent:
             kwargs['headers']['User-Agent'] = self.__user_agent
 
-        if stream_csv:
-            kwargs['stream'] = True
-            kwargs['headers']['Accept'] = 'text/csv'
-
         with metrics.http_request_timer(endpoint) as timer:
             response = self.__session.request(method, url, **kwargs)
             timer.tags[metrics.Tag.http_status_code] = response.status_code
@@ -124,8 +120,6 @@ class EloquaClient(object):
 
         response.raise_for_status()
 
-        if stream_csv:
-            return response
         return response.json()
 
     def get(self, path, **kwargs):

--- a/tap_eloqua/client.py
+++ b/tap_eloqua/client.py
@@ -111,6 +111,9 @@ class EloquaClient(object):
         if self.__user_agent:
             kwargs['headers']['User-Agent'] = self.__user_agent
 
+        if method == 'POST':
+            kwargs['headers']['Content-Type'] = 'application/json'
+
         with metrics.http_request_timer(endpoint) as timer:
             response = self.__session.request(method, url, **kwargs)
             timer.tags[metrics.Tag.http_status_code] = response.status_code

--- a/tap_eloqua/sync.py
+++ b/tap_eloqua/sync.py
@@ -208,6 +208,7 @@ def sync_bulk_obj(client, catalog, state, start_date, stream_name, bulk_page_siz
             json=params,
             endpoint='export_create_def')
 
+        time.sleep(30)
         data = client.post(
             '/api/bulk/2.0/syncs',
             json={
@@ -215,6 +216,7 @@ def sync_bulk_obj(client, catalog, state, start_date, stream_name, bulk_page_siz
             },
             endpoint='export_create_sync')
 
+        time.sleep(30)
         sync_id = re.match(r'/syncs/([0-9]+)', data['uri']).groups()[0]
 
         LOGGER.info('{} - Created export - {}'.format(stream_name, sync_id))
@@ -249,6 +251,7 @@ def sync_bulk_obj(client, catalog, state, start_date, stream_name, bulk_page_siz
                         sleep))
             time.sleep(sleep)
 
+    time.sleep(30)
     stream_export(client,
                   state,
                   catalog,

--- a/tap_eloqua/sync.py
+++ b/tap_eloqua/sync.py
@@ -69,7 +69,7 @@ def persist_records(catalog, stream_id, records, activity_type=None):
     with metrics.record_counter(stream_id) as counter:
         for record in records:
             if activity_type is not None:
-                # NB: Synthesize CreatedAt here as a workaround to fix activity exports
+                # NB: Synthesize CreatedAt here as a workaround to fix activity exports (PR #19)
                 record['CreatedAt'] = record['ActivityDate']
             with Transformer(
                 integer_datetime_fmt=UNIX_SECONDS_INTEGER_DATETIME_PARSING) as transformer:
@@ -193,7 +193,7 @@ def sync_bulk_obj(client, catalog, state, start_date, stream_name, bulk_page_siz
     if activity_type is not None:
         _filter += " AND '{{Activity.Type}}' = '" + activity_type + "'"
         # NB: We observed shuffled data when Activity.CreatedAt was specified twice in the query.
-        #     The key 'CreatedAt' is synthetic, so add it in after the export.
+        #     The key 'CreatedAt' is synthetic, so add it in after the export. (PR #19)
         fields.pop('CreatedAt', None)
 
     params = {

--- a/tap_eloqua/sync.py
+++ b/tap_eloqua/sync.py
@@ -175,7 +175,7 @@ def sync_bulk_obj(client, catalog, state, start_date, stream_name, bulk_page_siz
 
     num_fields = len(fields.values())
     if num_fields > 250:
-        LOGGER.error('{} - Exports can only have 250 fields selected. {} are selected.'.format(
+        raise Exception('{} - Exports can only have 250 fields selected. {} are selected.'.format(
             stream_name, num_fields))
     else:
         LOGGER.info('{} - Syncing {} fields'.format(stream_name, num_fields))

--- a/tap_eloqua/sync.py
+++ b/tap_eloqua/sync.py
@@ -1,5 +1,4 @@
 import re
-import csv
 import time
 import random
 from datetime import datetime, timedelta
@@ -63,28 +62,19 @@ def write_schema(catalog, stream_id):
     schema = stream.schema.to_dict()
     singer.write_schema(stream_id, schema, stream.key_properties)
 
-def persist_records(catalog, stream_id, records, updated_at_field=None):
+def persist_records(catalog, stream_id, records):
     stream = catalog.get_stream(stream_id)
     schema = stream.schema.to_dict()
     stream_metadata = metadata.to_map(stream.metadata)
-    max_updated_at = None
     with metrics.record_counter(stream_id) as counter:
-        total_count = 0
         for record in records:
             with Transformer(
                 integer_datetime_fmt=UNIX_SECONDS_INTEGER_DATETIME_PARSING) as transformer:
                 record = transformer.transform(record,
                                                schema,
                                                stream_metadata)
-                if updated_at_field:
-                    updated_at_value = record[updated_at_field]
-                    if max_updated_at is None or updated_at_value > max_updated_at:
-                        max_updated_at = updated_at_value
-
             singer.write_record(stream_id, record)
             counter.increment()
-            total_count += 1
-        return total_count, max_updated_at
 
 def transform_export_row(row):
     out = {}
@@ -114,35 +104,31 @@ def stream_export(client,
             stream_name,
             offset,
             bulk_page_size))
-        with metrics.job_timer('export_page'):
-            stream = client.get(
-                '/api/bulk/2.0/syncs/{}/data'.format(sync_id),
-                params={
-                    'limit': bulk_page_size,
-                    'offset': offset
-                },
-                stream_csv=True,
-                endpoint='export_data')
-            offset += bulk_page_size
 
-            records_stream = (line.decode('utf-8') for line in stream.iter_lines())
-            records = csv.DictReader(records_stream)
-            records_transformed = map(transform_export_row, records)
+        write_bulk_bookmark(state, stream_name, sync_id, offset, bookmark_datetime)
 
-            count, max_page_updated_at = persist_records(
-                catalog,
-                stream_name,
-                records_transformed,
-                updated_at_field=updated_at_field)
+        data = client.get(
+            '/api/bulk/2.0/syncs/{}/data'.format(sync_id),
+            params={
+                'limit': bulk_page_size,
+                'offset': offset
+            },
+            endpoint='export_data')
+        has_more = data['hasMore']
+        offset += bulk_page_size
 
+        if 'items' in data and data['items']:
+            records = map(transform_export_row, data['items'])
+            persist_records(catalog, stream_name, records)
+
+            max_page_updated_at = max(map(lambda x: x[updated_at_field], data['items']))
             if max_updated_at is None or max_page_updated_at > max_updated_at:
                 max_updated_at = max_page_updated_at
 
-            if count < bulk_page_size:
-                has_more = False
+    final_datetime = max_updated_at or bookmark_datetime
+    write_bulk_bookmark(state, stream_name, None, None, final_datetime)
 
-    if max_updated_at:
-        write_bookmark(state, stream_name, max_updated_at)
+    return final_datetime
 
 def sync_bulk_obj(client, catalog, state, start_date, stream_name, bulk_page_size, activity_type=None):
     LOGGER.info('{} - Starting export'.format(stream_name))


### PR DESCRIPTION
Eloqua has a bug in the backend where fields that are repeated in the request cause the values to be misaligned in the response. For example, in PageView activities.

```
"fields": {
        "VisitorId": "{{Activity.Visitor.Id}}",
        "VisitorExternalId": "{{Activity.Visitor.ExternalId}}",
        "ActivityDate": "{{Activity.CreatedAt}}",
        "CampaignName": "{{Activity.Campaign.Field(CampaignName)}}",
        "CampaignId": "{{Activity.Campaign.Id}}",
        "ContactId": "{{Activity.Contact.Id}}",
        "IpAddress": "{{Activity.Field(IpAddress)}}",
        "ExternalCampaignId": "{{Activity.Campaign.Field(CRMCampaignId)}}",
        "ReferrerUrl": "{{Activity.Field(ReferrerUrl)}}",
        "Url": "{{Activity.Field(Url)}}",
        "WebVisitId": "{{Activity.Field(WebVisitId)}}",
        "ActivityType": "{{Activity.Type}}",
        "ExternalId": "{{Activity.ExternalId}}",
        "IsWebTrackingOptedIn": "{{Activity.Field(IsWebTrackingOptedIn)}}",
        "LinkedToContactDate": "{{Activity.Field(LinkedToContactDate)}}",
        "CreatedAt": "{{Activity.CreatedAt}}",
        "Id": "{{Activity.Id}}"
    }
```

The duplication of `{{Activity.CreatedAt}}` for both `CreatedAt` and `ActivityDate` fields caused this issue.

This PR keeps the schema the same, but removes the extraneous field (`CreatedAt` in the keys) during the bulk request for Activity types.