### PR TITLE
Add request parameter to clean up our reports after 3 days

### DIFF
--- a/tap_eloqua/sync.py
+++ b/tap_eloqua/sync.py
@@ -214,6 +214,7 @@ def sync_bulk_obj(client, catalog, state, start_date, stream_name, bulk_page_siz
         'fields': fields,
         'filter': _filter,
         'areSystemTimestampsInUTC': True,
+        'autoDeleteDuration': 'P3D',
         'dataRetentionDuration': 'P3D' # 3 days in ISO-8601 duration notation this can be increased up to 14 days
     }
 


### PR DESCRIPTION
# Description of change
The export definitions created by the tap are not cleaned up. This PR sets the reports to be cleaned up after 3 days.

# Manual QA steps
 - Testing with two connections
 
# Risks
 - Low, should only effect Eloqua's backend
 
# Rollback steps
 - revert this branch
