### PR TITLE
Save sync_id bookmark directly after the export is created

### DIFF
--- a/tap_eloqua/sync.py
+++ b/tap_eloqua/sync.py
@@ -248,6 +248,8 @@ def sync_bulk_obj(client, catalog, state, start_date, stream_name, bulk_page_siz
 
         LOGGER.info('{} - Created export - {}'.format(stream_name, sync_id))
 
+        write_bulk_bookmark(state, stream_name, sync_id, 0, last_date_raw)
+
         sleep = 0
         start_time = time.time()
         while True:


### PR DESCRIPTION
# Description of change
In cases where a sync times out, the tap would submit a new export the next time it was run. This PR is to save the sync_id in state so that it can continue polling if interrupted due to timeout or other extraneous circumstances.

# Manual QA steps
 - Ran through a sync and confirmed that the bookmark was saved, then nulled out after export.
 
# Risks
 - Low, bookmarking more frequently is a good thing.
 
# Rollback steps
 - revert this branch and bump patch version
