### PR TITLE
limit setuptools to 51.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           command: |
             python3 -mvenv /usr/local/share/virtualenvs/tap-eloqua
             source /usr/local/share/virtualenvs/tap-eloqua/bin/activate
-            pip install -U 'pip<19.2' setuptools
+            pip install -U 'pip<19.2' 'setuptools<51.0.0'
             pip install .[dev]
       - add_ssh_keys
 workflows:


### PR DESCRIPTION
# Description of change
Limit setuptools to below version 51.0.0 to prevent conflicts.

# Manual QA steps
 - None.
 
# Risks
 - None, change to package version installed for tests build.
 
# Rollback steps
 - revert this branch
