### PR TITLE
[TDL-15656] Added Support for dev mode

### DIFF
--- a/tap_eloqua/__init__.py
+++ b/tap_eloqua/__init__.py
@@ -51,6 +51,8 @@ def parse_args(required_config_keys):
     -d,--discover   Run in discover mode
     -p,--properties Properties file: DEPRECATED, please use --catalog instead
     --catalog       Catalog file
+    -dev, --dev     Runs the tap in dev mode
+
 
     Returns the parsed args object from argparse. For each argument that
     point to JSON files (config, state, properties), we will automatically
@@ -80,6 +82,11 @@ def parse_args(required_config_keys):
         action='store_true',
         help='Do schema discovery')
 
+    parser.add_argument(
+        '-dev', '--dev',
+        action='store_true',
+        help='Runs tap in dev mode')
+
     args = parser.parse_args()
     if args.config:
         setattr(args, 'config_path', args.config)
@@ -106,13 +113,16 @@ def parse_args(required_config_keys):
 def main():
     #parsed_args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
     parsed_args = parse_args(REQUIRED_CONFIG_KEYS)
-
+    if parsed_args.dev:
+        LOGGER.warning("Executing Tap in Dev mode",)    
     with EloquaClient(parsed_args.config_path,
                       parsed_args.config['client_id'],
                       parsed_args.config['client_secret'],
                       parsed_args.config['refresh_token'],
                       parsed_args.config['redirect_uri'],
-                      parsed_args.config.get('user_agent')) as client:
+                      parsed_args.config.get('user_agent'),
+                      parsed_args.dev
+                      ) as client:
 
         if parsed_args.discover:
             do_discover(client)

--- a/tap_eloqua/client.py
+++ b/tap_eloqua/client.py
@@ -5,7 +5,7 @@ import sys
 import backoff
 import requests
 from requests.exceptions import ConnectionError
-from singer import metrics,get_logger
+from singer import metrics,get_logger,strptime,strftime
 
 LOGGER = get_logger()
 
@@ -53,7 +53,7 @@ class EloquaClient(object):
                     config = json.load(tap_config)
                 self.__access_token = config['access_token']
                 self.__refresh_token = config['refresh_token']
-                self.__expires=config['expires_in']
+                self.__expires=strptime(config['expires_in'])
             except KeyError as _:
                 LOGGER.fatal("Unable to locate key %s in config",_)
                 sys.exit(1)
@@ -106,7 +106,7 @@ class EloquaClient(object):
                 config = json.load(file)
             config['refresh_token'] = data['refresh_token']
             config['access_token'] = data['access_token']
-            config['expires_in'] = data['expires_in']
+            config['expires_in'] = strftime(datetime.utcnow() + timedelta(seconds=data['expires_in']))
             with open(self.__config_path, 'w') as file:
                 json.dump(config, file, indent=2)
 


### PR DESCRIPTION
# Description of change
Add support for `-dev` / `--dev` cli param, 
- prevent `refresh_token` expiry while running in dev-mode
- stores the current `access_token` and `expiry` in config
- exits tap if existing `access_token` is not available

# Manual QA steps
 -  First run the tap normally using the standard params
 - Check the config file for added keys `access_token` & `expires_in`
 -  Run the tap using the `--dev` or '-dev' param
 - Check the loglife for dev mode related logs 
 
# Risks (Very Low)
 - Tap will exit for existing connections when run in dev mode if access_token is not available
 
# Rollback steps
 - revert this branch
